### PR TITLE
Add additional maven-settings.xml for external repositoris

### DIFF
--- a/maven-settings.xml
+++ b/maven-settings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<settings xmlns="http://maven.apache.org/settings/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <profiles>
+        <profile>
+            <id>restlet-repository</id>   
+				<repositories>
+				    <repository>
+				        <id>maven-restlet</id>
+				        <name>Public online Restlet repository</name>
+				        <url>http://maven.restlet.org</url>
+				    </repository>
+				</repositories>         
+			</profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>restlet-repository</activeProfile>
+    </activeProfiles>
+
+</settings>
+

--- a/maven-settings.xml
+++ b/maven-settings.xml
@@ -5,13 +5,18 @@
 	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
 	<profiles>
 		<profile>
-			<id>external-repositories</id>   
+			<id>restlet</id>   
 			<repositories>
 				<repository>
 					<id>maven-restlet</id>
 					<name>Public online Restlet repository</name>
 					<url>http://maven.restlet.org</url>
 				</repository>
+			</repositories>         
+		</profile>
+		<profile>
+			<id>jboss</id>   
+			<repositories>
 				<repository>
 					<id>jboss-3rd-party-releases</id>
 					<url>https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/</url>
@@ -20,8 +25,8 @@
 		</profile>
 	</profiles>
 	<activeProfiles>
-		<activeProfile>external-repositories</activeProfile>
+		<activeProfile>restlet</activeProfile>
+		<activeProfile>jboss</activeProfile>		
 	</activeProfiles>
-
 </settings>
 

--- a/maven-settings.xml
+++ b/maven-settings.xml
@@ -1,23 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <settings xmlns="http://maven.apache.org/settings/1.0.0"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
-    <profiles>
-        <profile>
-            <id>restlet-repository</id>   
-				<repositories>
-				    <repository>
-				        <id>maven-restlet</id>
-				        <name>Public online Restlet repository</name>
-				        <url>http://maven.restlet.org</url>
-				    </repository>
-				</repositories>         
-			</profile>
-    </profiles>
-    <activeProfiles>
-        <activeProfile>restlet-repository</activeProfile>
-    </activeProfiles>
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+	<profiles>
+		<profile>
+			<id>external-repositories</id>   
+			<repositories>
+				<repository>
+					<id>maven-restlet</id>
+					<name>Public online Restlet repository</name>
+					<url>http://maven.restlet.org</url>
+				</repository>
+				<repository>
+					<id>jboss-3rd-party-releases</id>
+					<url>https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/</url>
+				</repository>
+			</repositories>         
+		</profile>
+	</profiles>
+	<activeProfiles>
+		<activeProfile>external-repositories</activeProfile>
+	</activeProfiles>
 
 </settings>
 


### PR DESCRIPTION
The added file includes 2 external repositories to resolve the required dependencies for the build. 
Then, it's possible to build the project without modifying the user's settings.xml but instead by doing:

```bash
mvn clean package -DskipTests -s maven-settings.xml
```